### PR TITLE
Assert auth scope + updateUser in AuthApiHelper

### DIFF
--- a/src/api/assertions.js
+++ b/src/api/assertions.js
@@ -126,6 +126,17 @@ function assertUserSignedIn(user) {
 }
 
 /**
+ * Checks if authApiHelper has a token in its authScope
+ * @param {!AuthApiHelper} authApiHelper - The user to be checked.
+ */
+function assertAuthScope(authApiHelper) {
+	const authScope = authApiHelper.resolveAuthScope();
+	if (!authScope || !authScope.token) {
+		throw new Error('You must have some type of authorization');
+	}
+}
+
+/**
  * Checks if an URL with a valid path is provided. Throws an exception
  * if the provided URL doesn't have a valid path.
  * @param {!string} url The URL to be checked.
@@ -168,6 +179,7 @@ function assertValidFieldTypes(fieldTypes) {
 }
 
 export {
+	assertAuthScope,
   assertBrowserEnvironment,
   assertDefAndNotNull,
   assertFunction,

--- a/src/api/auth/AuthApiHelper.js
+++ b/src/api/auth/AuthApiHelper.js
@@ -152,6 +152,23 @@ class AuthApiHelper extends ApiHelper {
   }
 
   /**
+   * Updates user by id.
+   * @param {!string} userId
+   * @param {!Object} data
+   * @return {CancellablePromise}
+   */
+  updateUser(userId, data) {
+    assertDefAndNotNull(userId, 'Cannot update user without id');
+    assertObject(data, 'User data must be specified as object');
+    assertAuthScope(this);
+    return this.buildUrl_()
+      .path('/users', userId)
+      .auth(this.resolveAuthScope().token)
+      .patch(data)
+      .then(response => assertResponseSucceeded(response));
+  }
+
+  /**
    * Gets all auth users
    * @param {!string} userId
    * @return {CancellablePromise}

--- a/src/api/auth/AuthApiHelper.js
+++ b/src/api/auth/AuthApiHelper.js
@@ -39,6 +39,7 @@ import GoogleAuthProvider from './GoogleAuthProvider';
 import {Storage, LocalStorageMechanism} from 'metal-storage';
 
 import {
+	assertAuthScope,
   assertDefAndNotNull,
   assertFunction,
   assertObject,
@@ -142,7 +143,7 @@ class AuthApiHelper extends ApiHelper {
    */
   deleteUser(userId) {
     assertDefAndNotNull(userId, 'Cannot delete user without id');
-    assertUserSignedIn(this.currentUser);
+    assertAuthScope(this);
     return this.buildUrl_()
       .path('/users', userId)
       .auth(this.resolveAuthScope().token)
@@ -156,7 +157,7 @@ class AuthApiHelper extends ApiHelper {
    * @return {CancellablePromise}
    */
   getAllUsers() {
-    assertUserSignedIn(this.currentUser);
+    assertAuthScope(this);
     return this.buildUrl_()
       .path('/users')
       .auth(this.resolveAuthScope().token)
@@ -203,7 +204,7 @@ class AuthApiHelper extends ApiHelper {
 	 */
   getUser(userId) {
     assertDefAndNotNull(userId, 'User userId must be specified');
-    assertUserSignedIn(this.currentUser);
+    assertAuthScope(this);
     return this.buildUrl_()
       .path('/users', userId)
       .auth(this.resolveAuthScope().token)

--- a/test/api/auth/AuthApiHelper.js
+++ b/test/api/auth/AuthApiHelper.js
@@ -513,7 +513,7 @@ describe('AuthApiHelper', function() {
 
     it('should call getUser successfully', function(done) {
       const auth = WeDeploy.auth('http://localhost');
-      auth.currentUser = {};
+      auth.currentUser = {token: 'token'};
       RequestMock.intercept().reply(200);
       auth.getUser('userId').then(user => {
         assert.ok(user instanceof Auth);
@@ -523,7 +523,7 @@ describe('AuthApiHelper', function() {
 
     it('should call getUser unsuccessfully', function(done) {
       const auth = WeDeploy.auth('http://localhost');
-      auth.currentUser = {};
+      auth.currentUser = {token: 'token'};
       RequestMock.intercept().reply(400);
       auth.getUser('userId').catch(() => done());
     });
@@ -532,7 +532,7 @@ describe('AuthApiHelper', function() {
       done
     ) {
       const auth = WeDeploy.auth('http://localhost');
-      auth.currentUser = {};
+      auth.currentUser = {token: 'token'};
       const responseErrorObject = {
         error: true,
       };
@@ -547,7 +547,7 @@ describe('AuthApiHelper', function() {
 
     it('should set headers on getUser', function(done) {
       const auth = WeDeploy.auth('http://localhost');
-      auth.currentUser = {};
+      auth.currentUser = {token: 'token'};
       RequestMock.intercept().reply(200);
       auth
         .header('TestHost', 'localhost')
@@ -580,7 +580,7 @@ describe('AuthApiHelper', function() {
 
     it('should call getAllUsers successfully', function(done) {
       const auth = WeDeploy.auth('http://localhost');
-      auth.currentUser = {};
+      auth.currentUser = {token: 'token'};
       const user1 = {
         createdAt: 'createdAt1',
         email: 'email1',
@@ -610,7 +610,7 @@ describe('AuthApiHelper', function() {
 
     it('should call getAllUsers unsuccessfully', function(done) {
       const auth = WeDeploy.auth('http://localhost');
-      auth.currentUser = {};
+      auth.currentUser = {token: 'token'};
       RequestMock.intercept().reply(400);
       auth.getAllUsers().catch(() => done());
     });
@@ -628,14 +628,14 @@ describe('AuthApiHelper', function() {
 
     it('should call deleteUser successfully', function(done) {
       const auth = WeDeploy.auth('http://localhost');
-      auth.currentUser = {};
+      auth.currentUser = {token: 'token'};
       RequestMock.intercept('DELETE', 'http://localhost/users/id').reply(200);
       auth.deleteUser('id').then(() => done());
     });
 
     it('should call deleteUser unsuccessfully', function(done) {
       const auth = WeDeploy.auth('http://localhost');
-      auth.currentUser = {};
+      auth.currentUser = {token: 'token'};
       RequestMock.intercept('DELETE', 'http://localhost/users/id').reply(400);
       auth.deleteUser('id').catch(() => done());
     });
@@ -644,7 +644,7 @@ describe('AuthApiHelper', function() {
       done
     ) {
       const auth = WeDeploy.auth('http://localhost');
-      auth.currentUser = {};
+      auth.currentUser = {token: 'token'};
       const responseErrorObject = {
         error: true,
       };

--- a/test/api/auth/AuthApiHelper.js
+++ b/test/api/auth/AuthApiHelper.js
@@ -616,6 +616,59 @@ describe('AuthApiHelper', function() {
     });
   });
 
+  describe('update User', function() {
+    beforeEach(function() {
+      RequestMock.setup('PATCH', 'http://localhost/users/id');
+    });
+
+    it('should throw exception when calling updateUser without user having id', function() {
+      const auth = WeDeploy.auth('http://localhost');
+      auth.currentUser = {token: 'token'};
+      assert.throws(() => auth.updateUser(), Error);
+    });
+
+    it('should throw exception when calling updateUser without user having data', function() {
+      const auth = WeDeploy.auth('http://localhost');
+      auth.currentUser = {token: 'token'};
+      assert.throws(() => auth.updateUser('id'), Error);
+    });
+
+    it('should call updateUser successfully', function(done) {
+      const auth = WeDeploy.auth('http://localhost');
+      auth.currentUser = {token: 'token'};
+      RequestMock.intercept('PATCH', 'http://localhost/users/id').reply(200);
+      auth.updateUser('id', {}).then(() => done());
+    });
+
+    it('should call updateUser unsuccessfully', function(done) {
+      const auth = WeDeploy.auth('http://localhost');
+      auth.currentUser = {token: 'token'};
+      RequestMock.intercept('PATCH', 'http://localhost/users/id').reply(400);
+      auth.updateUser('id', {}).catch(() => done());
+    });
+
+    it('should call updateUser unsuccessfully with error response as reason', function(
+      done
+    ) {
+      const auth = WeDeploy.auth('http://localhost');
+      auth.currentUser = {token: 'token'};
+      const responseErrorObject = {
+        error: true,
+      };
+      RequestMock.intercept('PATCH', 'http://localhost/users/id').reply(
+        400,
+        JSON.stringify(responseErrorObject),
+        {
+          'content-type': 'application/json',
+        }
+      );
+      auth.updateUser('id', {}).catch(reason => {
+        assert.deepEqual(responseErrorObject, reason);
+        done();
+      });
+    });
+  });
+
   describe('delete User', function() {
     beforeEach(function() {
       RequestMock.setup('DELETE', 'http://localhost/users/id');


### PR DESCRIPTION
1. Created `updateUser` method inside `AuthApiHelper`, similar to `deleteUser`
1. `updateUser`, `deleteUser`, `getAllUsers`, and `getUser` should not necessarily require a currentUser. They should also allow using the masterToken instead.

This should also solve #206 

Doc changes at https://github.com/wedeploy/wedeploy.com/pull/327