### PR TITLE
Load Socket.io explicitly instead to expect to be exposed to window

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wedeploy",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1806,27 +1806,10 @@
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
       "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
     },
-    "clone-buffer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
-      "dev": true
-    },
     "clone-stats": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
       "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
-    },
-    "cloneable-readable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
-      "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "process-nextick-args": "1.0.7",
-        "through2": "2.0.3"
-      }
     },
     "co": {
       "version": "4.6.0",
@@ -1936,15 +1919,6 @@
         "inherits": "2.0.3",
         "readable-stream": "2.3.3",
         "typedarray": "0.0.6"
-      }
-    },
-    "concat-with-sourcemaps": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.4.tgz",
-      "integrity": "sha1-9Vs74q60dgGxCi1SWcz7cP0vHdY=",
-      "dev": true,
-      "requires": {
-        "source-map": "0.5.7"
       }
     },
     "configstore": {
@@ -4810,51 +4784,6 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
           "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
           "dev": true
-        }
-      }
-    },
-    "gulp-concat": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.1.tgz",
-      "integrity": "sha1-Yz0WyV2IUEYorQJmVmPO5aR5M1M=",
-      "dev": true,
-      "requires": {
-        "concat-with-sourcemaps": "1.0.4",
-        "through2": "2.0.3",
-        "vinyl": "2.1.0"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-          "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
-          "dev": true
-        },
-        "clone-stats": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-          "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-          "dev": true
-        },
-        "replace-ext": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-          "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
-          "dev": true
-        },
-        "vinyl": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
-          "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
-          "dev": true,
-          "requires": {
-            "clone": "2.1.1",
-            "clone-buffer": "1.0.0",
-            "clone-stats": "1.0.0",
-            "cloneable-readable": "1.0.0",
-            "remove-trailing-separator": "1.1.0",
-            "replace-ext": "1.0.0"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "del": "^2.2.2",
     "eslint-config-liferay": "^1.0.1",
     "gulp": "^3.9.1",
-    "gulp-concat": "^2.6.1",
     "gulp-eslint": "^3.0.1",
     "gulp-mocha": "^4.3.1",
     "gulp-replace": "^0.6.1",

--- a/src/api/WeDeploy.js
+++ b/src/api/WeDeploy.js
@@ -30,6 +30,7 @@
 
 'use strict';
 
+import SocketIo from 'socket.io-client';
 import globals from '../globals/globals';
 import {core} from 'metal';
 import Auth from './auth/Auth';
@@ -46,13 +47,8 @@ import {MultiMap} from 'metal-structs';
 import Uri from 'metal-uri';
 import {assertDefAndNotNull, assertUriWithNoPath} from './assertions';
 
-let io;
+let io = SocketIo;
 let FormDataImpl;
-
-// Optimistic initialization of `io` reference from global `globals.window.io`.
-if (typeof globals.window !== 'undefined') {
-  io = globals.window.io;
-}
 
 // Optimistic initialization of `FormData` reference from global
 // `globals.window.FormData`.


### PR DESCRIPTION
Hey @eduardolundgren, this PR looks like a solution to the following problem:
1. If you import or require WeDeploy and bundle it using Webpack, there is no `window.io` exposed and [this](https://github.com/wedeploy/wedeploy-sdk-js/blob/b309741530f27947aac7443064ceabf3673c700b/src/api/WeDeploy.js#L52-L55) code does not set `io`. Then, if one tries to use `watch` on data, it [throws](https://github.com/wedeploy/wedeploy-sdk-js/blob/b309741530f27947aac7443064ceabf3673c700b/src/api/WeDeploy.js#L571-L573) the following exception "Socket.io client not loaded".  This does not happen if you directly add WeDeploy via `script` element - `window.io` is there in this case.

One solution could be to remove this optimistic logic and to go with more pessimistic one, which would be to set `io` explicitly. Since we have Webpack, there is no need to concatenate Socket.io, Webpack will do for us. Could you spot a better solution, or some problem with this one?

Thanks,
