### PR TITLE
Add follow_redirect option to requests made with Node.js + tests

### DIFF
--- a/src/api/ClientRequest.js
+++ b/src/api/ClientRequest.js
@@ -47,6 +47,7 @@ class ClientRequest extends ClientMessage {
     super();
     this.params_ = new MultiMap();
     this.withCredentials_ = false;
+    this.followRedirect_ = true;
   }
 
   /**
@@ -63,6 +64,22 @@ class ClientRequest extends ClientMessage {
       return this;
     }
     return this.withCredentials_;
+  }
+
+  /**
+	 * Fluent getter and setter for follow redirect option.
+	 * @param {boolean=} opt_followRedirect
+	 * @return {!ClientRequest|boolean} Returns the {@link ClientMessage} object
+	 *   itself when used as setter, otherwise returns the current value of follow
+	 *   redirect option.
+	 * @chainable Chainable when used as setter.
+	 */
+  followRedirect(opt_followRedirect) {
+    if (core.isDef(opt_followRedirect)) {
+      this.followRedirect_ = !!opt_followRedirect;
+      return this;
+    }
+    return this.followRedirect_;
   }
 
   /**

--- a/src/api/WeDeploy.js
+++ b/src/api/WeDeploy.js
@@ -88,6 +88,7 @@ class WeDeploy {
     this.headers_ = new MultiMap();
     this.params_ = new MultiMap();
     this.withCredentials_ = false;
+    this.followRedirect_ = true;
 
     this.header('Content-Type', 'application/json');
     this.header('X-Requested-With', 'XMLHttpRequest');
@@ -199,6 +200,7 @@ class WeDeploy {
     clientRequest.params(this.params());
     clientRequest.url(this.url());
     clientRequest.withCredentials(this.withCredentials_);
+    clientRequest.followRedirect(this.followRedirect_);
 
     this.encode(clientRequest);
 
@@ -535,6 +537,17 @@ class WeDeploy {
 	 */
   url() {
     return this.url_;
+  }
+
+  /**
+   * Indicate whether or not to follow redirects.
+   * @param {!boolean} followRedirect
+   * @return {WeDeploy} Returns the {@link WeDeploy} object itself, so calls can
+	 *   be chained.
+   */
+  followRedirect(followRedirect) {
+    this.followRedirect_ = followRedirect;
+    return this;
   }
 
   /**

--- a/src/api/browser/AjaxTransport.js
+++ b/src/api/browser/AjaxTransport.js
@@ -44,6 +44,10 @@ class AjaxTransport extends Transport {
 	 * @inheritDoc
 	 */
   send(clientRequest) {
+    if (!clientRequest.followRedirect()) {
+      console.warn('Disabling redirects is not supported in the browser');
+    }
+
     let url = new Uri(clientRequest.url());
 
     if (url.isUsingDefaultProtocol()) {

--- a/src/api/node/NodeTransport.js
+++ b/src/api/node/NodeTransport.js
@@ -54,7 +54,7 @@ class NodeTransport extends Transport {
       clientRequest.headers(),
       clientRequest.params(),
       null,
-      false
+      clientRequest.followRedirect()
     );
 
     return deferred.then(function(response) {
@@ -79,10 +79,19 @@ class NodeTransport extends Transport {
 	 * @param {MultiMap} opt_headers
 	 * @param {MultiMap} opt_params
 	 * @param {number=} opt_timeout
+   * @param {boolean} opt_follow_redirect
 	 * @return {CancellablePromise} Deferred ajax request.
 	 * @protected
 	 */
-  request(url, method, body, opt_headers, opt_params, opt_timeout) {
+  request(
+    url,
+    method,
+    body,
+    opt_headers,
+    opt_params,
+    opt_timeout,
+    opt_follow_redirect
+  ) {
     url = new Uri(url);
 
     if (url.isUsingDefaultProtocol()) {
@@ -120,6 +129,11 @@ class NodeTransport extends Transport {
 
     if (opt_timeout) {
       options.timeout = opt_timeout;
+    }
+
+    if (!opt_follow_redirect) {
+      options.followRedirect = false;
+      options.simple = false;
     }
 
     let connection;

--- a/test/api/WeDeploy.js
+++ b/test/api/WeDeploy.js
@@ -35,6 +35,7 @@ import Embodied from '../../src/api-query/Embodied';
 import Filter from '../../src/api-query/Filter';
 import WeDeploy from '../../src/api/WeDeploy';
 import Transport from '../../src/api/Transport';
+import NodeRequestMock from '../fixtures/node/NodeRequestMock';
 
 /* eslint-disable max-len,require-jsdoc */
 describe('WeDeploy Tests', function() {
@@ -647,6 +648,62 @@ describe('WeDeploy Tests', function() {
         const body = response.request().body();
         assert.ok(!(body instanceof FormData));
         assert.strictEqual('{}', body);
+        done();
+      });
+  });
+
+  it('it should follow redirect if followRedirect is true * For node requests only', function(
+    done
+  ) {
+    if (RequestMock !== NodeRequestMock) {
+      done();
+    }
+    RequestMock.intercept('GET', 'http://localhost/final').reply(
+      200,
+      'The End'
+    );
+    RequestMock.intercept('GET', 'http://localhost/redirected').reply(
+      302,
+      undefined,
+      {
+        Location: 'http://localhost/final',
+      }
+    );
+
+    WeDeploy.url('http://localhost/redirected')
+      .followRedirect(true)
+      .get()
+      .then(function(response) {
+        assert.strictEqual(response.statusCode(), 200);
+        assert.strictEqual(response.body(), 'The End');
+        done();
+      });
+  });
+
+  it('it should not follow redirects if followRedirect is false * For node requests only', function(
+    done
+  ) {
+    if (RequestMock !== NodeRequestMock) {
+      done();
+    }
+    RequestMock.intercept('GET', 'http://localhost/final').reply(
+      200,
+      'The End'
+    );
+    RequestMock.intercept('GET', 'http://localhost/redirected').reply(
+      302,
+      undefined,
+      {
+        Location: 'http://localhost/final',
+      }
+    );
+
+    WeDeploy.url('http://localhost/redirected')
+      .followRedirect(false)
+      .get()
+      .then(function(response) {
+        assert.strictEqual(response.statusCode(), 302);
+        assert.strictEqual(response.body(), '');
         done();
       });
   });


### PR DESCRIPTION
We can now disable following redirects in Node with `followRedirect(false)`:

```
WeDeploy.url('http://localhost')
  .followRedirect(false)
  .get()
```

We can use this option to fix https://github.com/wedeploy/api/issues/678
  